### PR TITLE
XBUSACK pin PORTE0/Arduino 23 set to output mode/high

### DIFF
--- a/CAT/CERBERUS_2100_BIOS/CERBERUS_2100_BIOS.ino
+++ b/CAT/CERBERUS_2100_BIOS/CERBERUS_2100_BIOS.ino
@@ -172,6 +172,7 @@ void setup() {
   	pinMode(CPUGO, OUTPUT);
   	pinMode(CPURST, OUTPUT);
   	pinMode(SOUND, OUTPUT);
+    pinMode(XBUSACK, OUTPUT);
   	/** Writing default values to some of the output pins **/
   	digitalWrite(RW, HIGH);
   	digitalWrite(SO, LOW);
@@ -183,6 +184,7 @@ void setup() {
   	digitalWrite(CPUIRQ, LOW);
   	digitalWrite(CPUGO, LOW);
   	digitalWrite(CPURST, LOW);
+    digitalWrite(XBUSACK, HIGH);
 	  // Attach an interrupt to XIRQ so to react to the expansion card timely
   	cli();	
 	PCICR  |= 0b00001000;  // Enables Port E Pin Change Interrupts


### PR DESCRIPTION
The XBUSACK pin at FAT CAT (Arduino pin 23 on PORT E0) is not initialized as output pin during setup(), defaulting to an input pin and never lowered in response to a XBUSREQ request. The call to DigitalWrite(XBUSACK. LOW) is there in code, but the port is electrically not lowered due to it's default input state.

Current behavior: the Cerberus seems to lock up after the external card asks for XBUSREQ. The external card is then waiting for XBUSACK indefinitely with XBUSREQ lowered, while CAT is waiting for the card to release the bus, which never happens.
This was a fun challenge to figure out, but with this small change it works just fine ;-)
