### PR TITLE
Support for file streaming commands: Open/Close/Read/Seek

### DIFF
--- a/CAT/CERBERUS_2100_BIOS/CERBERUS_2100_BIOS.ino
+++ b/CAT/CERBERUS_2100_BIOS/CERBERUS_2100_BIOS.ino
@@ -423,13 +423,19 @@ void messageHandler(void) {
 					}
 					break;
 				case 0x08: 
-					status = cmdFileRead(address);
+					status = cmdFileClose(address);
 					if(status != STATUS_READY) {
 						retVal = (byte)(status + 0x80);
 					}
 					break;
 				case 0x09: 
-					status = cmdFileClose(address);
+					status = cmdFileRead(address);
+					if(status != STATUS_READY) {
+						retVal = (byte)(status + 0x80);
+					}
+					break;
+				case 0x0A: 
+					status = cmdFileSeek(address);
 					if(status != STATUS_READY) {
 						retVal = (byte)(status + 0x80);
 					}
@@ -520,6 +526,12 @@ int cmdFileOpen(unsigned int address) {
     return fileOpen((char *)editLine);
 }
 
+// Handle closing a file
+int cmdFileClose(unsigned int address) {
+    fileHandle.close();
+    return STATUS_READY;
+}
+
 // Handle reading from a file
 int cmdFileRead(unsigned int address) {
     int result;
@@ -530,10 +542,10 @@ int cmdFileRead(unsigned int address) {
     return result;
 }
 
-// Handle closing a file
-int cmdFileClose(unsigned int address) {
-    fileHandle.close();
-    return STATUS_READY;
+// Handle seeking in a file
+int cmdFileSeek(unsigned int address) {
+    unsigned long filePosition = cpeekL(address);
+    return fileHandle.seek(filePosition) ? STATUS_READY : STATUS_EOF;
 }
 
 /************************************************************************************************/
@@ -1302,6 +1314,10 @@ byte cpeek(unsigned int address) {
 
 unsigned int cpeekW(unsigned int address) {
   return (cpeek(address) | (cpeek(address+1) << 8));
+}
+
+unsigned long cpeekL(unsigned int address) {
+  return (((unsigned long)cpeek(address)) | (((unsigned long)cpeek(address+1)) << 8) | (((unsigned long)cpeek(address+2)) << 16) | (((unsigned long)cpeek(address+3)) << 24));
 }
 
 boolean cpeekStr(unsigned int address, volatile char * dest, int max) {


### PR DESCRIPTION
The current file load command can only load a whole file at a time, which makes loading parts of a file impossible if the file is bigger then the available free memory, so I've added support for common file streaming commands.  You can now open a file, seek to a particular location, and read from it.

Here's a summary of the new commands...

- Command 0x07: **FileOpen** _(Open the file with the given name)_
address+0 = Filename

- Command 0x08: **FileClose** _(Close the currently open file)_

- Command 0x09: **FileRead** _(Read from the currently open file)_
_On entry:_
address+0 = Start address (2 bytes) _Where to load the file in memory_
address+2 = Byte count (2 bytes) _How many bytes of the file to load_
_On exit:_
address+2 = Byte read (2 bytes) _The number of bytes actually loaded_

- Command 0x0A: **FileSeek** _(Seek to the given position in the file)_
address+0 = File position (4 bytes) _How many bytes through the file to seek to_
